### PR TITLE
Define dummy functions

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,7 +4,14 @@
       "target_name": "wasi_node",
       "sources": [
         "./src/main.cc",
-        "./src/fd_prestat_get.cc"
+        "./src/fd_prestat_get.cc",
+        "./src/fd_prestat_dir_name.cc",
+        "./src/environ_sizes_get.cc",
+        "./src/environ_get.cc",
+        "./src/args_sizes_get.cc",
+        "./src/args_get.cc",
+        "./src/proc_exit.cc",
+        "./src/fd_fdstat_get.cc"
       ]
     },
   ]

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "dependencies": {
     "node-addon-api": "^1.7.1",
     "node-gyp": "^5.0.3"
+  },
+  "devDependencies": {
+    "jest": "^24.9.0"
   }
 }

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const {promisify} = require('util');
+const wasi = require('../index');
+
+promisify(fs.readFile)(process.argv[2])
+.then(data => WebAssembly.instantiate(data, wasi))
+.then(({instance}) => {
+  wasi.init(instance);
+  instance.exports._start()
+})
+.catch(err => {
+  console.error(err)
+})

--- a/src/api.hpp
+++ b/src/api.hpp
@@ -2,6 +2,10 @@
 #define WASI_NODE_APIS
 
 #include <node_api.h>
+#include <stdint.h>
+
+#define napi_get_pointer_value(env, value, result, lossless) \
+  (sizeof(void*) == sizeof(uint32_t)) ? napi_get_value_uint32(env, value, result) : napi_get_value_bigint_int64(env, value, result, lossless)
 
 namespace wasi_node {
 

--- a/src/api.hpp
+++ b/src/api.hpp
@@ -10,6 +10,13 @@
 namespace wasi_node {
 
 napi_value fd_prestat_get(napi_env env, napi_callback_info args);
+napi_value fd_prestat_dir_name(napi_env env, napi_callback_info args);
+napi_value environ_sizes_get(napi_env env, napi_callback_info args);
+napi_value environ_get(napi_env env, napi_callback_info args);
+napi_value args_sizes_get(napi_env env, napi_callback_info args);
+napi_value args_get(napi_env env, napi_callback_info args);
+napi_value proc_exit(napi_env env, napi_callback_info args);
+napi_value fd_fdstat_get(napi_env env, napi_callback_info args);
 
 }
 

--- a/src/args_get.cc
+++ b/src/args_get.cc
@@ -1,0 +1,19 @@
+#include <node_api.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include "wasi_core.h"
+#include "api.hpp"
+
+namespace wasi_node {
+
+napi_value args_get(napi_env env, napi_callback_info cbinfo) {
+  // TODO: 
+  printf("args_get\n");
+  // Result
+  napi_value result;
+  if(napi_create_int32(env, __WASI_ESUCCESS, &result) != napi_ok) return nullptr;
+  return result;
+}
+
+} // namespace wasi_node

--- a/src/args_sizes_get.cc
+++ b/src/args_sizes_get.cc
@@ -1,0 +1,19 @@
+#include <node_api.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include "wasi_core.h"
+#include "api.hpp"
+
+namespace wasi_node {
+
+napi_value args_sizes_get(napi_env env, napi_callback_info cbinfo) {
+  // TODO: 
+  printf("args_sizes_get\n");
+  // Result
+  napi_value result;
+  if(napi_create_int32(env, __WASI_ESUCCESS, &result) != napi_ok) return nullptr;
+  return result;
+}
+
+} // namespace wasi_node

--- a/src/environ_get.cc
+++ b/src/environ_get.cc
@@ -1,0 +1,19 @@
+#include <node_api.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include "wasi_core.h"
+#include "api.hpp"
+
+namespace wasi_node {
+
+napi_value environ_get(napi_env env, napi_callback_info cbinfo) {
+  // TODO: 
+  printf("environ_get\n");
+  // Result
+  napi_value result;
+  if(napi_create_int32(env, __WASI_ESUCCESS, &result) != napi_ok) return nullptr;
+  return result;
+}
+
+} // namespace wasi_node

--- a/src/environ_sizes_get.cc
+++ b/src/environ_sizes_get.cc
@@ -1,0 +1,19 @@
+#include <node_api.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include "wasi_core.h"
+#include "api.hpp"
+
+namespace wasi_node {
+
+napi_value environ_sizes_get(napi_env env, napi_callback_info cbinfo) {
+  // TODO: 
+  printf("environ_sizes_get\n");
+  // Result
+  napi_value result;
+  if(napi_create_int32(env, __WASI_ESUCCESS, &result) != napi_ok) return nullptr;
+  return result;
+}
+
+} // namespace wasi_node

--- a/src/fd_fdstat_get.cc
+++ b/src/fd_fdstat_get.cc
@@ -1,0 +1,19 @@
+#include <node_api.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include "wasi_core.h"
+#include "api.hpp"
+
+namespace wasi_node {
+
+napi_value fd_fdstat_get(napi_env env, napi_callback_info cbinfo) {
+  // TODO: 
+  printf("fd_fdstat_get\n");
+  // Result
+  napi_value result;
+  if(napi_create_int32(env, __WASI_ESUCCESS, &result) != napi_ok) return nullptr;
+  return result;
+}
+
+} // namespace wasi_node

--- a/src/fd_prestat_dir_name.cc
+++ b/src/fd_prestat_dir_name.cc
@@ -1,0 +1,19 @@
+#include <node_api.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include "wasi_core.h"
+#include "api.hpp"
+
+namespace wasi_node {
+
+napi_value fd_prestat_dir_name(napi_env env, napi_callback_info cbinfo) {
+  // TODO: 
+  printf("fd_prestat_dir_name\n");
+  // Result
+  napi_value result;
+  if(napi_create_int32(env, __WASI_ESUCCESS, &result) != napi_ok) return nullptr;
+  return result;
+}
+
+} // namespace wasi_node

--- a/src/fd_prestat_get.cc
+++ b/src/fd_prestat_get.cc
@@ -1,18 +1,29 @@
 #include <node_api.h>
+#include <stddef.h>
+#include <stdio.h>
 
+#include "wasi_core.h"
 #include "api.hpp"
 
 namespace wasi_node {
 
-napi_value fd_prestat_get(napi_env env, napi_callback_info args) {
-  
-  napi_value greeting;
+napi_value fd_prestat_get(napi_env env, napi_callback_info cbinfo) {
+  // Unfold callback info
+  size_t argc = 2;
+  napi_value argv[2];
+  napi_value thisArg;
+  void *data;
+  if(napi_get_cb_info(env, cbinfo, &argc, argv, &thisArg, &data) != napi_ok) return nullptr;
 
-  if (napi_create_string_utf8(env, "fd_prestat_get", NAPI_AUTO_LENGTH, &greeting) != napi_ok){
-    return nullptr;
-  }
+  // Get args
+  __wasi_fd_t fd;
+  if(napi_get_value_uint32(env, argv[0], &fd)) return nullptr;
+  printf("fd: %d\n", fd);
 
-  return greeting;
+  // Result
+  napi_value result;
+  if(napi_create_int32(env, __WASI_ESUCCESS, &result) != napi_ok) return nullptr;
+  return result;
 }
 
 } // namespace wasi_node

--- a/src/main.cc
+++ b/src/main.cc
@@ -2,17 +2,42 @@
 
 #include "api.hpp"
 
-#define WASI_NODE_INIT_API(method, name) \
-  if (napi_create_function(env, nullptr, 0, method, nullptr, &module) != napi_ok) return nullptr; \
-  if (napi_set_named_property(env, exports, name, module) != napi_ok) return nullptr;
+#include <stdio.h>
+
+#define WASI_NODE_INIT_API(module, method, func, name) \
+  if (napi_create_function(env, nullptr, 0, func, nullptr, &method) != napi_ok) return nullptr; \
+  if (napi_set_named_property(env, module, name, method) != napi_ok) return nullptr;
 
 namespace wasi_node {
 
+napi_value initInstance(napi_env env, napi_callback_info cbinfo) {
+  // Get argument (instance)
+  size_t argc = 1;
+  napi_value argv;
+  napi_value thisArg;
+  void *data;
+  if(napi_get_cb_info(env, cbinfo, &argc, &argv, &thisArg, &data) != napi_ok) return nullptr;
+  // Get this name
+  napi_value props;
+  napi_get_property_names(env, thisArg, &props);
+  uint32_t propCount;
+  napi_get_array_length(env, props, &propCount);
+  printf("thisCount: %u\n", propCount);
+  return nullptr;
+}
+
 napi_value initialize(napi_env env, napi_value exports) {
   napi_value module;
+  if (napi_create_object(env, &module) != napi_ok) return nullptr;
+  
+  napi_value method;
+  WASI_NODE_INIT_API(module, method, fd_prestat_get, "fd_prestat_get");
 
-  WASI_NODE_INIT_API(fd_prestat_get, "fd_prestat_get");
-
+  // module.exports.wasi_unstable
+  if (napi_set_named_property(env, exports, "wasi_unstable", module) != napi_ok) return nullptr;
+  // module.exports.init
+  if (napi_create_function(env, nullptr, 0, initInstance, nullptr, &method) != napi_ok) return nullptr;
+  if (napi_set_named_property(env, exports, "init", method) != napi_ok) return nullptr;
   return exports;
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -32,6 +32,13 @@ napi_value initialize(napi_env env, napi_value exports) {
   
   napi_value method;
   WASI_NODE_INIT_API(module, method, fd_prestat_get, "fd_prestat_get");
+  WASI_NODE_INIT_API(module, method, fd_prestat_dir_name, "fd_prestat_dir_name");
+  WASI_NODE_INIT_API(module, method, environ_sizes_get, "environ_sizes_get");
+  WASI_NODE_INIT_API(module, method, environ_get, "environ_get");
+  WASI_NODE_INIT_API(module, method, args_sizes_get, "args_sizes_get");
+  WASI_NODE_INIT_API(module, method, args_get, "args_get");
+  WASI_NODE_INIT_API(module, method, proc_exit, "proc_exit");
+  WASI_NODE_INIT_API(module, method, fd_fdstat_get, "fd_fdstat_get");
 
   // module.exports.wasi_unstable
   if (napi_set_named_property(env, exports, "wasi_unstable", module) != napi_ok) return nullptr;

--- a/src/proc_exit.cc
+++ b/src/proc_exit.cc
@@ -1,0 +1,19 @@
+#include <node_api.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include "wasi_core.h"
+#include "api.hpp"
+
+namespace wasi_node {
+
+napi_value proc_exit(napi_env env, napi_callback_info cbinfo) {
+  // TODO: 
+  printf("proc_exit\n");
+  // Result
+  napi_value result;
+  if(napi_create_int32(env, __WASI_ESUCCESS, &result) != napi_ok) return nullptr;
+  return result;
+}
+
+} // namespace wasi_node

--- a/src/wasi_core.h
+++ b/src/wasi_core.h
@@ -11,12 +11,14 @@
 #ifndef __wasi_core_h
 #define __wasi_core_h
 
-#ifndef __wasi__
-#error <wasi/core.h> is only supported on WASI platforms.
-#endif
-
 #include <stddef.h>
 #include <stdint.h>
+
+#ifdef __cplusplus
+#define _Static_assert static_assert
+#define _Alignof alignof
+extern "C" {
+#endif
 
 _Static_assert(_Alignof(int8_t) == 1, "non-wasi data layout");
 _Static_assert(_Alignof(uint8_t) == 1, "non-wasi data layout");
@@ -26,10 +28,6 @@ _Static_assert(_Alignof(int32_t) == 4, "non-wasi data layout");
 _Static_assert(_Alignof(uint32_t) == 4, "non-wasi data layout");
 _Static_assert(_Alignof(int64_t) == 8, "non-wasi data layout");
 _Static_assert(_Alignof(uint64_t) == 8, "non-wasi data layout");
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 typedef uint8_t __wasi_advice_t;
 #define __WASI_ADVICE_NORMAL     (UINT8_C(0))
@@ -448,6 +446,7 @@ _Static_assert(
 _Static_assert(sizeof(__wasi_subscription_t) == 56, "non-wasi data layout");
 _Static_assert(_Alignof(__wasi_subscription_t) == 8, "non-wasi data layout");
 
+/*
 #define __WASI_SYSCALL_NAME(name) \
     __attribute__((__import_module__("wasi_unstable"), __import_name__(#name)))
 
@@ -734,11 +733,11 @@ __wasi_errno_t __wasi_sock_shutdown(
 
 __wasi_errno_t __wasi_sched_yield(void)
     __WASI_SYSCALL_NAME(sched_yield) __attribute__((__warn_unused_result__));
-
+*/
 #ifdef __cplusplus
 }
 #endif
 
-#undef __WASI_SYSCALL_NAME
+//#undef __WASI_SYSCALL_NAME
 
 #endif


### PR DESCRIPTION
I compiled a simple C source with wasi-sdk:

```c
int main(void){
  return 0;
}
```
Some APIs needs to be defined to instantiate this program, so I defined them in precede.